### PR TITLE
Skip to next day, if part_day has passed already

### DIFF
--- a/weather/1_voice_weather_forecast_local.yaml
+++ b/weather/1_voice_weather_forecast_local.yaml
@@ -461,7 +461,7 @@ triggers:
   - trigger: conversation
     command: !input trigger
 variables:
-  version: 20250313
+  version: 20250414.1
   daily_mapping:
     - phrases: !input today
       delta: 0

--- a/weather/1_voice_weather_forecast_local.yaml
+++ b/weather/1_voice_weather_forecast_local.yaml
@@ -588,10 +588,11 @@ actions:
           - alias: Define variables to determine which part to use
             variables:
               tomorrow: !input tomorrow
-              next_day: "{{ phrase is search(tomorrow | join('|')) }}"
-              delta: "{{ 1 if next_day else 0}}"
               start_time: "{{ day_part_mapping | selectattr('phrases', 'contains', phrase) | map(attribute='start') | list | first }}"
               end_time: "{{ day_part_mapping | selectattr('phrases', 'contains', phrase) | map(attribute='end') | list | first }}"
+              next_day: "{{ phrase is search(tomorrow | join('|')) }}"
+              skip_day: "{{ now() >= today_at(end_time) and not next_day }}"
+              delta: "{{ 1 if (next_day or skip_day) else 0 }}"
               start: "{{ today_at() + timedelta(days=delta) + as_timedelta(start_time) }}"
               end: "{{ today_at() + timedelta(days=delta) + as_timedelta(end_time) }}"
               day_part_forecast: >


### PR DESCRIPTION
This is for the local weather forecast blueprint.

If the requested `part_day` has already passed (e.g. asking for the morning forecast in the evening) then automatically assume "tomorrows" `part_day` is requested.

I know it is possible to specify "tomorrow" for the `part_day` but I feel it is more natural when the scripts does that automatically for me.