### PR TITLE
Fix a typo for the weather local blueprint

### DIFF
--- a/weather/1_voice_weather_forecast_local.yaml
+++ b/weather/1_voice_weather_forecast_local.yaml
@@ -93,7 +93,7 @@ blueprint:
           default:
             - "what('s| is) [this|next] ({phrase}[']s|the|this) weather [forecast]"
             - "what('s| is) the weather [forecast] [for] [this|next] ({phrase}|day)"
-            - "what('ll| will) the weather [forecast] be [like] [[for] [[the] coming|this] ({pharse}|day)]"
+            - "what('ll| will) the weather [forecast] be [like] [[for] [[the] coming|this] ({phrase}|day)]"
     daily_forecast_settings:
       name: Settings for the daily forecast.
       icon: mdi:chat


### PR DESCRIPTION
Fix a typo: use `phrase` instead of `pharse`