### PR TITLE
Process reminders correctly if LLM provides wrong data format

### DIFF
--- a/reminder/0_voice_send_reminder.yaml
+++ b/reminder/0_voice_send_reminder.yaml
@@ -46,7 +46,7 @@ blueprint:
     Nothing from your side is needed, the automation will check every minute if there are todo items due, and perform
     the actions if this is the case."
   homeassistant:
-    min_version: 2024.3.999
+    min_version: 2025.4.0
   input:
     general_settings:
       name: General settings
@@ -142,6 +142,7 @@ blueprint:
 
 triggers: !input triggers
 variables:
+  version: 2025.6.0
   todo_entity: !input todo_entity
   recipients: !input recipients
   recipient_data: >
@@ -175,7 +176,16 @@ actions:
             text: !input recipient_prompt
           response_variable: recipient_llm_raw
         - variables:
-            recipients_llm: "{{ recipient_llm_raw.response.speech.plain.speech }}"
+            recipients_raw: "{{ recipient_llm_raw.response.speech.plain.speech }}"
+            reciptients_llm: >
+              {% set r = recipients_raw %}
+              {% if r is list %}
+                {{ r }}
+              {% elif r is string and r is search('\[*\]') %}
+                {{ r[r.index('['):r.index(']')+1] }}
+              {% elif r is string %}
+                {{ r.split(',') | map('trim') | list }}
+              {% endif %}
         - alias: "Repeat sending the notification for each recipient"
           repeat:
             for_each: "{{ recipients_llm }}"


### PR DESCRIPTION
Sometimes an LLM will not provide the recipient list as JSON, but it will add code tags or other explanation. Or it will provide it a a comma separated list.

This change will check for such incorrect responses, and process it into a proper list.

fixes #43