### PR TITLE
Fix: Handle missing forecast attributes in weather averaging template

### DIFF
--- a/weather/3_voice_weather_forecast_full_llm.yaml
+++ b/weather/3_voice_weather_forecast_full_llm.yaml
@@ -301,10 +301,18 @@ sequence:
 
               {% for item in forecast_keys %}
 
-              {% set combine = weather_data | map(attribute=item) | list %}
+              {% set combine = weather_data | map(attribute=item, default=none) | select('!=', none) | list %}
+
+              {% if combine | length > 0 %}
 
               {% set combine = combine | statistical_mode if combine[0] is string else combine
               | average | round %}
+
+              {% else %}
+
+              {% set combine = none %}
+
+              {% endif %}
 
               {% set ns.combined = dict(ns.combined, **{item: combine}) %}
 


### PR DESCRIPTION
- Added `default=none` to Jinja `map(attribute=...)` calls to avoid errors when forecast entries lack specific keys (e.g., `wind_speed`).
- Ensured that missing or undefined forecast attributes are treated as `None` and safely ignored in the averaging/statistical calculations.
- Improves robustness of the script when processing incomplete weather data from providers.