### PR TITLE
Fix telegram_bot actions

### DIFF
--- a/telegram/telegram_alert.yaml
+++ b/telegram/telegram_alert.yaml
@@ -29,7 +29,7 @@ blueprint:
 
     ```
   homeassistant:
-    min_version: 2025.11.0
+    min_version: 2026.3.0
   input:
     trigger_settings:
       name: Trigger settings
@@ -110,7 +110,9 @@ blueprint:
               multiple: true
               filter:
                 - integration: telegram_bot
-                  domain: event
+                  domain:
+                    - event
+                    - notify
         parse_mode:
           name: Parse mode
           description: "Parser for the message text: `markdownv2`, `html`, `markdown` or `plain_text` ."
@@ -504,7 +506,7 @@ actions:
                     action: telegram_bot.send_message
                     data:
                       config_entry_id: "{{ config_entry_id(repeat.item) }}"
-                      target: "{{ state_attr(repeat.item, 'chat_id')}}"
+                      chat_id: "{{ state_attr(repeat.item, 'chat_id')}}"
                       title: !input alert_title
                       message: !input alert_message
                       inline_keyboard: "{{ inline_keyboard }}"
@@ -619,7 +621,7 @@ actions:
                             action: telegram_bot.send_message
                             data:
                               config_entry_id: "{{ config_entry }}"
-                              target: "{{ chat_id }}"
+                              chat_id: "{{ chat_id }}"
                               title: "{{ alert_title if use_ack_title else '' }}"
                               message: "{{ acknowledge_message }}"
                               parse_mode: !input parse_mode
@@ -649,7 +651,7 @@ actions:
                                   action: telegram_bot.send_message
                                   data:
                                     config_entry_id: "{{ config_entry_id(repeat.item) }}"
-                                    target: "{{ state_attr(repeat.item, 'chat_id')}}"
+                                    chat_id: "{{ state_attr(repeat.item, 'chat_id')}}"
                                     title: "{{ alert_title if use_done_title else '' }}"
                                     message: "{{ done_message }}"
                                     parse_mode: !input parse_mode

--- a/telegram/telegram_assist.yaml
+++ b/telegram/telegram_assist.yaml
@@ -31,7 +31,7 @@ blueprint:
 
     ```
   homeassistant:
-    min_version: 2025.11.0
+    min_version: 2026.3.0
   input:
     telegram_event:
       name: Telegram event entity
@@ -119,7 +119,7 @@ actions:
     action: telegram_bot.send_message
     data:
       config_entry_id: "{{ config_entry }}"
-      target: "{{ chat_id }}"
+      chat_id: "{{ chat_id }}"
       message: "{{ response.response.speech.plain.speech }}"
       message_tag: conversation_response
 mode: parallel

--- a/telegram/telegram_command.yaml
+++ b/telegram/telegram_command.yaml
@@ -30,7 +30,7 @@ blueprint:
 
     ```
   homeassistant:
-    min_version: 2025.11.0
+    min_version: 2026.3.0
   input:
     chat_settings:
       name: Chat settings


### PR DESCRIPTION
2026.3 added a deprecation warning about using the chat_id under target for the telegram_bot.send_message action. 

This PR fixes the warnings about this, and uses the `chat_id` in the correct spot.